### PR TITLE
Configure intellisense to see STM32L083 headers

### DIFF
--- a/c_cpp_properties.json
+++ b/c_cpp_properties.json
@@ -1,0 +1,11 @@
+{
+    "configurations": [
+        {
+            "name": "STM32L083",
+            "defines": [
+                "STM32L083xx"
+            ]
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
This patch configures intellisense to implicitly define the macro
STM32L083xx. With the macro, intellisense will see the correct header
files and errors previously reported for undefined symbols such as
FLASH->ACR go away.