### PR TITLE
Simplify typical development workflow

### DIFF
--- a/tasks.json
+++ b/tasks.json
@@ -29,6 +29,25 @@
             }
         },
         {
+            "label": "build debug",
+            "args": ["-j4", "debug"],
+            "type": "shell",
+            "command": "make",
+            "problemMatcher": {
+                "owner": "cpp",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            },
+            "group": "build"
+        },
+        {
             "label": "dfu",
             "type": "shell",
             "args": ["dfu"]

--- a/tasks.json
+++ b/tasks.json
@@ -87,6 +87,25 @@
             "problemMatcher": []
         },
         {
+            // This task supports the typical development workflow:
+            //   1. Build a debug version of the firmware
+            //   2. Flash the firmware onto a device (without verification)
+            //   3. Attach to the device's log
+            //
+            // To run the task repeatedly, simply select "Restart Running Task"
+            // from VSCode's command pallete.
+
+            "label": "build+flash+log",
+            "type": "shell",
+            "command": "bcf",
+
+            "args": ["flash", "--skip-verify", "--log"],
+            "presentation": {"focus": true},
+            "problemMatcher": [],
+            "dependsOrder": "sequence",
+            "dependsOn": ["build debug"]
+        },
+        {
             "label": "ozone",
             "type": "shell",
             "args": ["ozone"]


### PR DESCRIPTION
The aim of these patches is to simplify the typical development workflow within VSCode when a single Core module is attached to the host. The new tasks allow building a debug version of the firmware, flashing it to the device, and attaching to its log with a single command.

For fully non-interactive experience (no character device selection), one either needs to select the device via the `--device` command line option to `bcf` in `.vscode/tasks.json`, or use a [modified version of `bcf`](https://github.com/hardwario/bch-firmware-tool/pull/6)